### PR TITLE
docs+chore: contributor guide, TS UI with Biome, CI, and minimal Go CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS defines who reviews and approves changes by path.
+# Update branch protection to "Require review from Code Owners" to enforce.
+
+# Default owner for entire repo
+* @frnwtr
+
+# UI (Next.js + TS)
+ui/ @frnwtr
+
+# Go CLI and backends
+cmd/ @frnwtr
+core/ @frnwtr
+docker/ @frnwtr
+tailscale/ @frnwtr
+traefik/ @frnwtr
+
+# Docs
+*.md @frnwtr

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the change and why it’s needed.
+
+## Linked Issues
+
+Closes #<issue>, Related to #<issue>
+
+## Changes
+
+- [ ] Feature
+- [ ] Fix
+- [ ] Docs
+- [ ] Refactor/Chore
+
+## Affected Areas
+
+- Modes: [ ] A (Host+Traefik) [ ] B (Sidecar) [ ] C (Funnel)
+- UI: [ ] Yes [ ] No
+- CLI/Go: [ ] Yes [ ] No
+
+## Screenshots (UI)
+
+If UI changed, add before/after screenshots.
+
+## Test & Checks
+
+- [ ] UI typecheck: `pnpm -C ui typecheck`
+- [ ] UI lint: `pnpm -C ui lint`
+- [ ] UI build: `pnpm -C ui build`
+- [ ] Go tests: `go test ./... -race -cover` (if applicable)
+- [ ] Conventional Commits for all commits
+
+## Notes for Reviewers
+
+Anything notable for deployment, migration, or follow-ups.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch: {}
+
+jobs:
+  ui:
+    name: ui
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for ui directory
+        id: detect
+        run: |
+          if [ -d ui ]; then echo "has_ui=true" >> $GITHUB_OUTPUT; else echo "has_ui=false" >> $GITHUB_OUTPUT; fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: 'ui/pnpm-lock.yaml'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Prepare pnpm
+        run: corepack prepare pnpm@latest --activate
+
+      - name: Install deps (ui)
+        if: steps.detect.outputs.has_ui == 'true'
+        run: pnpm -C ui install --frozen-lockfile=false
+
+      - name: Typecheck
+        if: steps.detect.outputs.has_ui == 'true'
+        run: pnpm -C ui typecheck
+
+      - name: Lint
+        if: steps.detect.outputs.has_ui == 'true'
+        run: pnpm -C ui lint
+
+      - name: Build
+        if: steps.detect.outputs.has_ui == 'true'
+        run: pnpm -C ui build
+
+      - name: Skip (no ui/)
+        if: steps.detect.outputs.has_ui != 'true'
+        run: echo "No ui/ directory; skipping UI checks."
+
+  go:
+    name: go
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect Go project
+        id: detect
+        run: |
+          if [ -f go.mod ] || git ls-files '*.go' | grep -q .; then
+            echo "has_go=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_go=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+
+      - name: Go env
+        if: steps.detect.outputs.has_go == 'true'
+        run: |
+          go version
+          go env GOPATH GOMOD
+
+      - name: Test
+        if: steps.detect.outputs.has_go == 'true'
+        run: go test ./... -race -cover
+
+      - name: Skip (no Go detected)
+        if: steps.detect.outputs.has_go != 'true'
+        run: echo "No Go files found; skipping tests."
+

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh" 2>/dev/null || true
+
+MSG_FILE="$1"
+FIRST_LINE="$(head -n1 "$MSG_FILE" 2>/dev/null)"
+
+# Allow merges, fixup/squash, and tag-only release commits
+echo "$FIRST_LINE" | grep -Eq '^(Merge|fixup!|squash!|Revert|v?[0-9]+\.[0-9]+\.[0-9]+$)' && exit 0
+
+TYPES='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|release'
+CONVENTIONAL_REGEX="^(${TYPES})(\([a-z0-9._-]+\))?(!)?: .+"
+
+if echo "$FIRST_LINE" | grep -Eq "$CONVENTIONAL_REGEX"; then
+  exit 0
+fi
+
+echo "\n✖ Commit message must follow Conventional Commits" >&2
+echo "  Got:   $FIRST_LINE" >&2
+echo "  Expect: <type>(scope)?: short description" >&2
+echo "  Types:  build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test,release" >&2
+echo "  Examples:" >&2
+echo "    feat(cli): add watch mode for Mode A" >&2
+echo "    fix(traefik): stable tls.yml sort order" >&2
+echo "    docs(readme): clarify Funnel mode" >&2
+exit 1
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh" 2>/dev/null || true
+
+# Ensure pnpm exists (Corepack or global)
+command -v pnpm >/dev/null 2>&1 || {
+  echo "[husky] pnpm not found; skipping UI checks" >&2
+  exit 0
+}
+
+# Run UI checks
+pnpm -C ui typecheck && pnpm -C ui lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `core/`: service discovery, naming, exposure modes. (planned)
+- `docker/`: Docker API access and event stream. (planned)
+- `tailscale/`: certs, MagicDNS checks, Funnel control. (planned)
+- `traefik/`: TLS file writer and watchers. (planned)
+- `cmd/tailwhale`: Go CLI entrypoint (sync, watch, list). (planned)
+- `cmd/extension-api`: REST backend for UI. (planned)
+- `ui/`: Next.js frontend (scaffolded in this repo).
+
+## Build, Test, and Development Commands
+- Node package manager: use `pnpm` (not npm/yarn). Enable via `corepack enable`. Do not commit `package-lock.json` or `yarn.lock`.
+- Make targets: `make build`, `make test`, `make dev` — wraps Go/UI tasks and no-ops if a part is missing.
+- Go build: `go build ./cmd/tailwhale` — builds the CLI (when available).
+- Go run: `go run ./cmd/tailwhale --help` — quick local run (when available).
+- Go tests: `go test ./...` — runs unit tests across modules.
+- UI dev: `cd ui && pnpm install && pnpm dev` — Next.js dev server.
+- UI build: `cd ui && pnpm build` — production build.
+
+## Node Setup (pnpm/Corepack)
+- Enable Corepack: `corepack enable`
+- Activate pnpm: `corepack prepare pnpm@latest --activate`
+- Verify: `pnpm -v`
+- First install in `ui/`: `cd ui && pnpm install`
+- Fallback (if Corepack unavailable): `npm i -g pnpm` then `pnpm -v`
+
+## Coding Style & Naming Conventions
+- Go: formatted by `gofmt`/`goimports`; package names lowercase; exported identifiers use CamelCase; errors with `%w` for wrapping; prefer `context.Context` and structured logs.
+- TypeScript/React (ui/): use Biome (`pnpm lint`, `pnpm format`) for lint+format; components PascalCase; files kebab-case; 2-space indent; keep strict `tsconfig`.
+- YAML (Traefik): 2-space indent; deterministic key ordering in `traefik/tls.yml`.
+
+## Testing Guidelines
+- Go: place tests in `*_test.go`; name `TestXxx`; prefer table-driven tests. Run `go test ./... -race -cover`. Aim for ~80% package-level coverage where practical.
+- UI: `cd ui && pnpm typecheck && pnpm lint && pnpm test` (tests stubbed initially). Add screenshots for UI PRs that change visuals.
+
+## Commit & Pull Request Guidelines
+- Commits: Conventional Commits style. Examples:
+  - `feat(cli): add watch mode for Mode A`
+  - `fix(traefik): stable tls.yml sort order`
+  - `docs(readme): clarify Funnel mode`
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`. Format: `type(scope)?: subject`.
+- Hook enforcement: Husky `commit-msg` validates Conventional Commits; `pre-commit` runs `pnpm -C ui typecheck && pnpm -C ui lint`. Run `pnpm install` in `ui/` so `prepare` installs hooks.
+- PRs: include description, linked issues, affected exposure modes (A/B/C), test evidence (`go test` output or UI screenshots), and upgrade notes if user-facing behavior changes. If UI deps change, commit `pnpm-lock.yaml` updates. Use the template in `.github/pull_request_template.md`.
+
+## Security & Configuration Tips
+- Never commit secrets; use `.env` and update `.env.example` when adding vars (e.g., Tailscale auth keys).
+- Restrict file writes to intended paths (e.g., `traefik/tls.yml`).
+- When using Funnel or MagicDNS, verify config with a dry run before enabling `watch`.
+
+## CI
+- Combined CI: `.github/workflows/ci.yml` runs two jobs on PRs:
+  - `ui`: pnpm install → typecheck → lint → build (skips if no `ui/`).
+  - `go`: `go test ./... -race -cover` (skips if no Go code).
+- Branch protection: in GitHub Settings → Branches, add a rule for your default branch and require status checks `CI / ui` and `CI / go`.
+
+## Code Owners
+- File: `.github/CODEOWNERS` assigns reviewers by path. Default owner is `@frnwtr` for the whole repo and key directories.
+- If collaborators/teams are added later, update paths to include their handles.
+- In branch protection, enable "Require review from Code Owners" to enforce.
+
+## Architecture Overview
+TailWhale syncs Docker → Tailscale certs → Traefik TLS. Choose Mode A (host + Traefik), Mode B (sidecar per container), or Mode C (Funnel on Traefik) based on deployment needs.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+SHELL := /bin/bash
+
+.PHONY: help build test dev ui-dev ui-build go-build go-test
+
+help:
+	@echo "Available targets:"
+	@echo "  build    - Build Go CLI (if present) and UI"
+	@echo "  test     - Run Go tests (if present) and UI tests"
+	@echo "  dev      - Start UI dev server (pnpm)"
+	@echo "  ui-dev   - Start UI dev server"
+	@echo "  ui-build - Build UI for production"
+	@echo "  go-build - Build Go CLI if cmd/tailwhale exists"
+	@echo "  go-test  - Run Go tests if Go sources exist"
+
+build: go-build ui-build
+
+test: go-test
+	@if [ -d ui ]; then \
+		cd ui && pnpm test; \
+	else \
+		echo "[skip] ui/ not found"; \
+	fi
+
+dev: ui-dev
+
+ui-dev:
+	@if [ -d ui ]; then \
+		cd ui && pnpm dev; \
+	else \
+		echo "ui/ not found. Create ui/ or run 'make help'"; \
+	fi
+
+ui-build:
+	@if [ -d ui ]; then \
+		cd ui && pnpm build; \
+	else \
+		echo "[skip] ui/ not found"; \
+	fi
+
+go-build:
+	@if [ -d cmd/tailwhale ]; then \
+		go build ./cmd/tailwhale; \
+	else \
+		echo "[skip] cmd/tailwhale not found"; \
+	fi
+
+go-test:
+	@if rg -uu --files | rg -q "\.go$$"; then \
+		go test ./...; \
+	else \
+		echo "[skip] no Go files found"; \
+	fi
+

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,11 @@
+# Next.js
+.next/
+out/
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,18 @@
+# TailWhale UI
+
+A minimal Next.js TypeScript app managed with pnpm and Biome.
+
+## Commands
+- Install deps: `pnpm install`
+- Dev server: `pnpm dev`
+- Build: `pnpm build`
+- Start: `pnpm start`
+- Typecheck: `pnpm typecheck`
+- Lint: `pnpm lint`
+- Format: `pnpm format`
+
+Enable Corepack globally with `corepack enable` and activate pnpm via `corepack prepare pnpm@latest --activate`.
+
+## Git Hooks
+- Husky pre-commit runs typecheck + lint from repo root.
+- After `pnpm install`, the `prepare` script auto-installs hooks.

--- a/ui/biome.json
+++ b/ui/biome.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": { "useValidAriaProps": "warn" },
+      "style": { "useConst": "warn" }
+    }
+  },
+  "organizeImports": { "enabled": true },
+  "vcs": { "clientKind": "git" }
+}
+

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig
+

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tailwhale-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prepare": "husky install",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --error-on-warnings .",
+    "format": "biome format --write .",
+    "test": "echo 'No UI tests yet' && exit 0"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.4",
+    "@biomejs/biome": "1.8.3",
+    "husky": "9.1.6"
+  },
+  "packageManager": "pnpm@9.7.0"
+}

--- a/ui/pages/api/health.ts
+++ b/ui/pages/api/health.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+type Health = { status: 'ok' }
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<Health>
+) {
+  res.status(200).json({ status: 'ok' })
+}
+

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -1,0 +1,17 @@
+export default function Home() {
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', padding: 24 }}>
+      <h1>TailWhale UI</h1>
+      <p>Next.js (TypeScript) app scaffolded with pnpm and Biome.</p>
+      <ul>
+        <li>dev: <code>pnpm dev</code></li>
+        <li>build: <code>pnpm build</code></li>
+        <li>start: <code>pnpm start</code></li>
+        <li>typecheck: <code>pnpm typecheck</code></li>
+        <li>lint: <code>pnpm lint</code></li>
+        <li>format: <code>pnpm format</code></li>
+      </ul>
+    </main>
+  );
+}
+

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}
+


### PR DESCRIPTION
This PR adds contributor guidelines and scaffolds the UI/dev tooling.

Why
- Establish clear contribution standards (tools, style, CI, PR process).
- Provide a minimal UI scaffold to unblock future work.
- Enforce consistency via Biome and Conventional Commits.

What’s included
- AGENTS.md: concise, repo-specific guidelines (pnpm, TS, Biome, tests, PR rules).
- UI scaffold (Next.js + TypeScript) under `ui/` with pnpm scripts.
- Biome config for lint/format; Husky hooks (pre-commit, commit-msg).
- Makefile targets for Go/UI (guarded when directories aren’t present).
- Consolidated CI (`.github/workflows/ci.yml`) with UI + Go jobs.
- PR template and CODEOWNERS (default @frnwtr).

Testing done
- Local `pnpm -C ui install && pnpm -C ui typecheck && pnpm -C ui lint && pnpm -C ui build`.
- CI workflows validate typecheck/lint/build on PRs.

Risks / Rollback
- Low; UI is isolated under `ui/`; revert by removing new files if needed.

Follow-ups
- Add Go CLI skeleton under `cmd/tailwhale` and extend tests.
- Wire UI to backend when available.

Post-merge checklist
- [ ] Enable branch protection: require checks “CI / ui” and “CI / go”.
- [ ] Verify CODEOWNERS reflects current collaborators.
- [ ] Initial UI build on main: `pnpm -C ui install && pnpm -C ui build`.
