### PR TITLE
feat(traefik): atomic TLS file writer and CLI sync integration

### DIFF
--- a/internal/fsx/atomic.go
+++ b/internal/fsx/atomic.go
@@ -1,0 +1,38 @@
+package fsx
+
+import (
+    "io"
+    "os"
+    "path/filepath"
+)
+
+// WriteFileAtomic writes data to path atomically via a temp file and rename.
+func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
+    dir := filepath.Dir(path)
+    if err := os.MkdirAll(dir, 0o755); err != nil { return err }
+    f, err := os.CreateTemp(dir, ".tmp-*")
+    if err != nil { return err }
+    tmp := f.Name()
+    defer func(){ _ = os.Remove(tmp) }()
+    if _, err := f.Write(data); err != nil { f.Close(); return err }
+    if err := f.Sync(); err != nil { f.Close(); return err }
+    if err := f.Close(); err != nil { return err }
+    if err := os.Chmod(tmp, perm); err != nil { return err }
+    return os.Rename(tmp, path)
+}
+
+// CopyAtomic copies from r to path atomically.
+func CopyAtomic(path string, r io.Reader, perm os.FileMode) error {
+    dir := filepath.Dir(path)
+    if err := os.MkdirAll(dir, 0o755); err != nil { return err }
+    f, err := os.CreateTemp(dir, ".tmp-*")
+    if err != nil { return err }
+    tmp := f.Name()
+    defer func(){ _ = os.Remove(tmp) }()
+    if _, err := io.Copy(f, r); err != nil { f.Close(); return err }
+    if err := f.Sync(); err != nil { f.Close(); return err }
+    if err := f.Close(); err != nil { return err }
+    if err := os.Chmod(tmp, perm); err != nil { return err }
+    return os.Rename(tmp, path)
+}
+

--- a/internal/fsx/atomic_test.go
+++ b/internal/fsx/atomic_test.go
@@ -1,0 +1,18 @@
+package fsx
+
+import (
+    "bytes"
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func TestWriteFileAtomic(t *testing.T){
+    dir := t.TempDir()
+    path := filepath.Join(dir, "a", "b", "file.txt")
+    if err := WriteFileAtomic(path, []byte("hello"), 0o644); err != nil { t.Fatal(err) }
+    got, err := os.ReadFile(path)
+    if err != nil { t.Fatal(err) }
+    if !bytes.Equal(got, []byte("hello")) { t.Fatalf("wrong content: %q", string(got)) }
+}
+


### PR DESCRIPTION
Adds atomic file writer and integrates CLI sync to write Traefik tls.yml.\n\nChanges\n- internal/fsx: WriteFileAtomic + tests.\n- cmd/tailwhale sync: writes tls.yml via traefik.MarshalYAML + atomic write.\n- Keeps fake provider; plumbing for real provider to be added.\n\nNext\n- Implement real Docker provider and Tailscale manager.\n- Add golden tests for tls.yml content.\n