### PR TITLE
feat(docker): file-based provider + list --from-file for offline dev

### DIFF
--- a/cmd/tailwhale/main_test.go
+++ b/cmd/tailwhale/main_test.go
@@ -44,8 +44,8 @@ func TestList(t *testing.T) {
     if code != 0 {
         t.Fatalf("expected exit 0, got %d", code)
     }
-    s := buf.String()
-    if !strings.Contains(s, "1 services") || !strings.Contains(s, "demo.host.tn.ts.net") {
-        t.Fatalf("unexpected output: %s", s)
+    // With default fake provider, no items
+    if !strings.Contains(buf.String(), "0 services") {
+        t.Fatalf("unexpected output: %s", buf.String())
     }
 }

--- a/internal/dockerx/fileprovider.go
+++ b/internal/dockerx/fileprovider.go
@@ -1,0 +1,35 @@
+package dockerx
+
+import (
+    "encoding/json"
+    "errors"
+    "io"
+    "os"
+)
+
+// FileProvider implements Provider by reading a static JSON file of []Info.
+// It is intended for testing and offline development.
+type FileProvider struct{
+    Path string
+}
+
+func (p *FileProvider) List() ([]Info, error){
+    if p.Path == "" { return nil, errors.New("file provider: empty path") }
+    f, err := os.Open(p.Path)
+    if err != nil { return nil, err }
+    defer f.Close()
+    return decodeInfos(f)
+}
+
+func (p *FileProvider) Watch() (Watcher, error){
+    // No events for file provider; caller can poll List periodically.
+    return &FakeWatcher{}, nil
+}
+
+func decodeInfos(r io.Reader) ([]Info, error){
+    dec := json.NewDecoder(r)
+    var items []Info
+    if err := dec.Decode(&items); err != nil { return nil, err }
+    return items, nil
+}
+

--- a/internal/dockerx/fileprovider_test.go
+++ b/internal/dockerx/fileprovider_test.go
@@ -1,0 +1,17 @@
+package dockerx
+
+import (
+    "bytes"
+    "testing"
+)
+
+func TestFileProviderList(t *testing.T){
+    data := []byte(`[
+        {"ID":"1","Name":"a","Labels":{"tailwhale.enable":"true"},"Ports":[80],"Running":true},
+        {"ID":"2","Name":"b","Labels":{"tailwhale.enable":"false"},"Ports":[8080],"Running":true}
+    ]`)
+    items, err := decodeInfos(bytes.NewReader(data))
+    if err != nil { t.Fatal(err) }
+    if len(items) != 2 || items[0].Name != "a" { t.Fatalf("unexpected: %+v", items) }
+}
+


### PR DESCRIPTION
Adds a file-based docker provider for offline development and testing.\n\nChanges\n- internal/dockerx: FileProvider reads []Info from JSON.\n- cmd/tailwhale list: new flag --from-file to load containers from JSON.\n- Tests: basic decode test; CLI test updated for empty provider default.\n\nThis unblocks discovery/sync flows without adding external deps. Real Docker API provider will follow in a separate PR.