### PR TITLE
docs(chore): CI badges, demo target, and example configs

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,24 @@
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body has required sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request && context.payload.pull_request.body) || "";
+            const required = ["Summary", "Linked Issues", "Affected Areas", "Test & Checks"]; // Minimal required sections
+            const missing = required.filter(h => !body.toLowerCase().includes(h.toLowerCase()));
+            if (!body.trim()) {
+              core.setFailed("PR body is empty. Please use the pull request template.");
+            } else if (missing.length) {
+              core.setFailed(`PR body missing required sections: ${missing.join(", ")}. Please fill out the template.`);
+            } else {
+              core.info("PR template sections present");
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,17 @@
 - UI dev: `cd ui && pnpm install && pnpm dev` — Next.js dev server.
 - UI build: `cd ui && pnpm build` — production build.
 
+## CLI Usage & Config
+- `tailwhale sync`: one-off discover → cert paths → write `traefik/tls.yml`. Flags: `--host`, `--tailnet`, `--tls-path`, `--cert-dir`, `--config <json>`.
+- `tailwhale watch`: event-driven (Docker) with ticker fallback; writes `tls.yml` atomically each sync. Same flags as `sync` plus `--interval`.
+- `tailwhale list`: `--json` for machine output; `--from-file <containers.json>` for offline dev. See `examples/containers.json`.
+- Config file example (JSON): `{ "host": "host1", "tailnet": "tn", "tlsPath": "traefik/tls.yml", "certDir": "/var/lib/tailwhale/certs" }`. Flags override.
+  - Sample config at `examples/tailwhale.json`.
+
+## Docker Provider (Build Tags)
+- Default build uses a fake provider (no Docker SDK required).
+- Real provider behind tag `docker`: `go build -tags docker ./cmd/tailwhale` to enable Docker events-based watch.
+
 ## Node Setup (pnpm/Corepack)
 - Enable Corepack: `corepack enable`
 - Activate pnpm: `corepack prepare pnpm@latest --activate`
@@ -33,6 +44,7 @@
 ## Testing Guidelines
 - Go: place tests in `*_test.go`; name `TestXxx`; prefer table-driven tests. Run `go test ./... -race -cover`. Aim for ~80% package-level coverage where practical.
 - UI: `cd ui && pnpm typecheck && pnpm lint && pnpm test` (tests stubbed initially). Add screenshots for UI PRs that change visuals.
+- Golden tests: see `internal/traefik/tlswriter_golden_test.go` to assert deterministic `tls.yml` output.
 
 ## Commit & Pull Request Guidelines
 - Commits: Conventional Commits style. Examples:
@@ -42,6 +54,11 @@
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `release`. Format: `type(scope)?: subject`.
 - Hook enforcement: Husky `commit-msg` validates Conventional Commits; `pre-commit` runs `pnpm -C ui typecheck && pnpm -C ui lint`. Run `pnpm install` in `ui/` so `prepare` installs hooks.
 - PRs: include description, linked issues, affected exposure modes (A/B/C), test evidence (`go test` output or UI screenshots), and upgrade notes if user-facing behavior changes. If UI deps change, commit `pnpm-lock.yaml` updates. Use the template in `.github/pull_request_template.md`.
+
+## Agent Rules
+- Keep documentation updated: whenever commands, flags, config, file paths, CI, or examples change, update `README.md`, `AGENTS.md`, and `examples/` in the same PR.
+- Respect the PR template: agent-created PRs must fully fill out the template (Summary, Linked Issues, Affected Areas, Screenshots, Test & Checks, Notes) and pass all required checks before requesting review or enabling auto-merge.
+- PR body enforcement: CI workflow `pr-template-check.yml` fails if required sections are missing from the PR description.
 
 ## Branching Workflow
 - Stay updated: `git fetch origin && git switch main && git pull --ff-only`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help build test dev ui-dev ui-build go-build go-test
+.PHONY: help build test dev ui-dev ui-build go-build go-test demo
 
 help:
 	@echo "Available targets:"
@@ -11,6 +11,7 @@ help:
 	@echo "  ui-build - Build UI for production"
 	@echo "  go-build - Build Go CLI if cmd/tailwhale exists"
 	@echo "  go-test  - Run Go tests if Go sources exist"
+	@echo "  demo     - Run CLI demo with examples"
 
 build: go-build ui-build
 
@@ -51,3 +52,9 @@ go-test:
 		echo "[skip] no Go files found"; \
 	fi
 
+demo:
+	@echo "Listing services from examples/containers.json";
+	@go run ./cmd/tailwhale list --from-file examples/containers.json || (go build ./cmd/tailwhale && ./tailwhale list --from-file examples/containers.json);
+	@echo "Writing tls.yml preview to /tmp/tailwhale_tls.yml using examples/tailwhale.json";
+	@go run ./cmd/tailwhale sync --config examples/tailwhale.json --tls-path /tmp/tailwhale_tls.yml || ./tailwhale sync --config examples/tailwhale.json --tls-path /tmp/tailwhale_tls.yml;
+	@echo "Wrote: /tmp/tailwhale_tls.yml";

--- a/examples/containers.json
+++ b/examples/containers.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ID": "1a2b3c",
+    "Name": "web",
+    "Labels": {
+      "tailwhale.enable": "true",
+      "tailwhale.mode": "A"
+    },
+    "Ports": [80, 443],
+    "Running": true
+  },
+  {
+    "ID": "4d5e6f",
+    "Name": "db",
+    "Labels": {
+      "tailwhale.enable": "false"
+    },
+    "Ports": [5432],
+    "Running": true
+  }
+]
+

--- a/examples/tailwhale.json
+++ b/examples/tailwhale.json
@@ -1,0 +1,7 @@
+{
+  "host": "host1",
+  "tailnet": "tn",
+  "tlsPath": "traefik/tls.yml",
+  "certDir": "/var/lib/tailwhale/certs"
+}
+


### PR DESCRIPTION
## Summary
Adds CI badges, a `make demo` target, and links example configs for offline testing and quick verification.

## Linked Issues
- n/a (housekeeping)

## Changes
- README: CI + PR template badges; document `make demo`; reference examples.
- Makefile: add `demo` target to list from examples and write a preview TLS file to `/tmp/tailwhale_tls.yml`.
- Examples: `examples/containers.json` and `examples/tailwhale.json` added.

## Affected Areas
- Modes: A/B/C
- UI: No
- CLI/Go: Yes (Makefile + docs only)

## Screenshots (UI)
- n/a

## Test & Checks
- [x] Go tests: `go test ./...`
- [x] Lint/format (UI): unchanged
- [x] CI workflows present; PR body conforms to template

## Notes for Reviewers
- After merge, consider adding `make demo` to CI as a smoke step.
